### PR TITLE
update file inputs to be gzipped

### DIFF
--- a/R/utils-barcodes.R
+++ b/R/utils-barcodes.R
@@ -27,8 +27,8 @@ read_molecules <- function(molecule_file,
 
   if (return_ids) {
     base_path <- fs::path_dir(molecule_file)
-    bcs_fn <- fs::path_join(c(base_path, "barcodes.tsv"))
-    features_fn <- fs::path_join(c(base_path, "features.tsv"))
+    bcs_fn <- fs::path_join(c(base_path, "barcodes.tsv.gz"))
+    features_fn <- fs::path_join(c(base_path, "features.tsv.gz"))
 
     if (!fs::file_exists(bcs_fn)) {
       stop(bcs_fn, " does not exist", call. = FALSE)


### PR DESCRIPTION
minor fix to use gzipped inputs for molecule files.

Also includes some example code to examine sequence saturation in specific features, and to plot barcode distributions for specific features. 

``` r
library(scrunchy)
library(tidyverse)
#> Warning: package 'tibble' was built under R version 3.5.2

base_url <- "http://amc-sandbox.ucdenver.edu/User33/hcut/haircut/molecules/"

files <- c(
  "molecules.tsv.gz",
  "barcodes.tsv.gz",
  "features.tsv.gz"
)

file_urls <- paste0(base_url, files)
walk2(file_urls, files, download.file)

mols <- read_molecules("molecules.tsv.gz")

# filter to keep cell associated barcodes only
bcs <- read_lines("http://amc-sandbox.ucdenver.edu/User33/hcut/mrna/barcodes.tsv.gz") %>% 
  gsub("-1$", "", .)

cell_mols <- mols %>% filter(barcode %in% bcs)

# Examine saturation 
plot_saturation(cell_mols)
#> downsampling reads
#> calculating sequence saturation
```

![](https://i.imgur.com/kmGedRu.png)

``` r
plot_saturation(cell_mols %>% filter(feature %in% c("Uracil_45", "riboG_44")))
#> downsampling reads
#> calculating sequence saturation
```

![](https://i.imgur.com/V2k5AYM.png)

``` r

# Examine barcodes
plot_barcodes(mols)
```

![](https://i.imgur.com/QxCPLQg.png)

``` r
plot_barcodes(mols %>% filter(feature %in% c("Uracil_45", "riboG_44")))
```

![](https://i.imgur.com/sCq5XXH.png)

<sup>Created on 2019-01-07 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>